### PR TITLE
Test tracking changes for multi-track, RepeatMode.off with logging

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -99,7 +99,7 @@ const App = () => {
     let mounted = true;
     (async () => {
       const track = await TrackPlayer.getTrack(index);
-      if (mounted) setTrack(track);
+      if (mounted) setTrack(track || undefined);
     })();
     return () => {
       mounted = false;
@@ -113,7 +113,8 @@ const App = () => {
     } else {
       TrackPlayer.play();
     }
-  }, [isPlaying]);
+  }, [isPlaying, index]);
+
 
   return (
     <SafeAreaView style={styles.screenContainer}>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -115,6 +115,12 @@ const App = () => {
     }
   }, [isPlaying, index]);
 
+  useTrackPlayerEvents(
+    [Event.PlaybackTrackChanged, Event.PlaybackQueueEnded],
+    async event => {
+      console.log(`${event.type} (hook)`, event);
+    },
+  );
 
   return (
     <SafeAreaView style={styles.screenContainer}>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -60,7 +60,7 @@ const setupPlayer = async () => {
         duration: 28,
       },
     ]);
-    await TrackPlayer.setRepeatMode(RepeatMode.Queue);
+    await TrackPlayer.setRepeatMode(RepeatMode.Off);
   } finally {
     return index;
   }

--- a/example/service.js
+++ b/example/service.js
@@ -35,4 +35,12 @@ module.exports = async function setup() {
       }
     }
   });
+
+  TrackPlayer.addEventListener(Event.PlaybackQueueEnded, data => {
+    console.log('PlaybackQueueEnded', data);
+  });
+
+  TrackPlayer.addEventListener(Event.PlaybackTrackChanged, data => {
+    console.log('PlaybackTrackChanged', data);
+  });
 };


### PR DESCRIPTION
## Context

This PR isn't meant to merge, but rather to demonstrate tracking event changes in doublesymmetry/react-native-track-player#1482.

Using the example app, it logs tracking events in two different ways for the multi-track playlist with `RepeatMode.off`.

## Issues
I observed two issues with the current state of the upstream PR:

**1. iOS (only) is firing a `PlaybackQueueEnded` event after each track plays to completion**, even if it's not the last track in the queue. I expect to see this event only when the last track in the queue ends. Note that this only happens if you let the track play to the end; if you skip ahead to the next one, this event is not logged. I didn't notice this originally because I was skipping ahead to the last track.

**2. The final `PlaybackTrackChanged` event is firing for listeners added via `TrackPlayer.addEventListener`, but not for listeners added via the `useTrackPlayerEvents` hook.** I have not yet investigated whether this is introduced by this PR or present in `main`. And it *only* happens with the last event as far as I can tell, so I wonder if it has something to do with the way it's fired [here](https://github.com/doublesymmetry/react-native-track-player/pull/1482/files#diff-94accf09a62b72cc24579dd49ff0e05cf7779667184464eb10efc4596bacf96cR824)

## Event logs

### Android
All of these tracks advanced naturally. The `PlaybackQueueEnded` event was fired only on the last track, but you can see that issue [2] above is present.

```
 LOG  Running "example" with {"rootTag":1}
 LOG  PlaybackTrackChanged {"nextTrack": 0, "position": 0}
 LOG  playback-track-changed (hook) {"nextTrack": 0, "position": 0, "type": "playback-track-changed"}

 LOG  PlaybackTrackChanged {"nextTrack": 1, "position": 0}
 LOG  playback-track-changed (hook) {"nextTrack": 1, "position": 0, "type": "playback-track-changed"}

 LOG  PlaybackTrackChanged {"nextTrack": 2, "position": 0}
 LOG  playback-track-changed (hook) {"nextTrack": 2, "position": 0, "type": "playback-track-changed"}

 LOG  PlaybackTrackChanged {"nextTrack": 3, "position": 0}
 LOG  playback-track-changed (hook) {"nextTrack": 3, "position": 0, "type": "playback-track-changed"}

 LOG  PlaybackTrackChanged {"nextTrack": 4, "position": 0}
 LOG  playback-track-changed (hook) {"nextTrack": 4, "position": 0, "type": "playback-track-changed"}

 LOG  PlaybackQueueEnded {"position": 28.309, "track": 4}
 LOG  playback-queue-ended (hook) {"position": 28.309, "track": 4, "type": "playback-queue-ended"}
 LOG  PlaybackTrackChanged {"position": 28.309, "track": 4}
```

### iOS
I annotated the issues in line with `// Annotation`

```
// Issue [1]: Track advanced naturally firing PlaybackQueueEnded event
 LOG  PlaybackQueueEnded {"position": 143.42639455782313, "track": 1}
 LOG  playback-queue-ended (hook) {"position": 143.42639455782313, "track": 1, "type": "playback-queue-ended"}
 LOG  PlaybackTrackChanged {"nextTrack": 1, "position": 143.42639455782313, "track": 0}
 LOG  playback-track-changed (hook) {"nextTrack": 1, "position": 143.42639455782313, "track": 0, "type": "playback-track-changed"}
 LOG  PlaybackTrackChanged {"position": 143.42639455782313, "track": 1}

// [Correct behavior]: Track advanced by clicking skip; no PlaybackQueueEnded event is present
 LOG  PlaybackTrackChanged {"nextTrack": 2, "position": 68.645564657, "track": 1}
 LOG  playback-track-changed (hook) {"nextTrack": 2, "position": 68.645564657, "track": 1, "type": "playback-track-changed"}

// Issue [1]: Track advanced naturally firing PlaybackQueueEnded event
 LOG  PlaybackQueueEnded {"position": 70.64925170068027, "track": 3}
 LOG  playback-queue-ended (hook) {"position": 70.64925170068027, "track": 3, "type": "playback-queue-ended"}
 LOG  PlaybackTrackChanged {"position": 70.64925170068027, "track": 3}
 LOG  playback-track-changed (hook) {"position": 70.64925170068027, "track": 3, "type": "playback-track-changed"}
 LOG  PlaybackTrackChanged {"nextTrack": 3, "position": 70.64925170068027, "track": 2}

// Issue [1]: Track advanced naturally firing PlaybackQueueEnded event
 LOG  PlaybackQueueEnded {"position": 105.57496598639456, "track": 4}
 LOG  playback-queue-ended (hook) {"position": 105.57496598639456, "track": 4, "type": "playback-queue-ended"}
 LOG  PlaybackTrackChanged {"nextTrack": 4, "position": 105.57496598639456, "track": 3}
 LOG  playback-track-changed (hook) {"nextTrack": 4, "position": 105.57496598639456, "track": 3, "type": "playback-track-changed"}

// Issue [2]: hook event missing
 LOG  PlaybackTrackChanged {"position": 105.57496598639456, "track": 4}
 LOG  PlaybackQueueEnded {"position": 28.305124716553287, "track": 4}
 LOG  playback-queue-ended (hook) {"position": 28.305124716553287, "track": 4, "type": "playback-queue-ended"}
```