### PR TITLE
fix skip method

### DIFF
--- a/web/TrackPlayer/PlaylistPlayer.ts
+++ b/web/TrackPlayer/PlaylistPlayer.ts
@@ -59,7 +59,7 @@ export class PlaylistPlayer extends Player {
     await this.load(track);
 
     if (initialPosition) {
-      await this.seekTo(initialPosition);
+      this.seekTo(initialPosition);
     }
 
     if (this.playWhenReady) {
@@ -87,10 +87,9 @@ export class PlaylistPlayer extends Player {
     }
 
     this.currentIndex = index;
-    await this.add([track]);
 
     if (initialPosition) {
-      await this.seekTo(initialPosition);
+      this.seekTo(initialPosition);
     }
   }
 

--- a/web/TrackPlayer/PlaylistPlayer.ts
+++ b/web/TrackPlayer/PlaylistPlayer.ts
@@ -56,8 +56,10 @@ export class PlaylistPlayer extends Player {
       throw new Error('playlist_exhausted');
     }
 
-    this.currentIndex = index;
-    await this.load(track);
+    if (this.currentIndex !== index) {
+      this.currentIndex = index;
+      await this.load(track);
+    }
 
     if (initialPosition) {
       this.seekTo(initialPosition);
@@ -87,11 +89,7 @@ export class PlaylistPlayer extends Player {
       throw new Error('index out of bounds');
     }
 
-    this.currentIndex = index;
-
-    if (initialPosition) {
-      this.seekTo(initialPosition);
-    }
+    await this.goToIndex(index, initialPosition);
   }
 
   public async skipToNext(initialPosition?: number) {

--- a/web/TrackPlayer/PlaylistPlayer.ts
+++ b/web/TrackPlayer/PlaylistPlayer.ts
@@ -37,6 +37,7 @@ export class PlaylistPlayer extends Player {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected onPlaylistEnded() {}
 
   protected get currentIndex() {
@@ -197,8 +198,11 @@ export class PlaylistPlayer extends Player {
   }
 
   // TODO
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public updateMetadataForTrack(index: number, metadata: Partial<Track>) {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public clearNowPlayingMetadata() {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public updateNowPlayingMetadata(metadata: Partial<Track>) {}
 
 }


### PR DESCRIPTION
It seems current implementation was trying to seek to a place in a track, while it should skip to a track and position.